### PR TITLE
Undefined meta causes the master process to crash

### DIFF
--- a/lib/winston-cluster.js
+++ b/lib/winston-cluster.js
@@ -64,7 +64,7 @@ var bindListeners = exports.bindListeners = function(options) {
             
             var level = msg.level;
             var message = msg.msg;
-            var meta = msg.meta;
+            var meta = msg.meta || { };
             meta.worker = msg.worker;
 
             winston.log(level, message, meta);


### PR DESCRIPTION
If `undefined` is passed in as the meta property, it causes an error which causes the master process to crash. as it then attempts to set `meta.worker` when `meta` is undefined. While passing in `undefined` as meta data isn't exactly helpful, it is something I can see happening by mistake and crashing the whole server seems like a bad idea.