### PR TITLE
Add static masterLogger, allows for multiple logger instances on master

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,14 +3,17 @@ import * as cluster from 'cluster';
 
 declare namespace winstonCluster {
   interface Cluster extends transportStream {
+    masterLogger: winston.Logger;
+
     name: string;
     silent: boolean;
     stripColors: boolean;
     loggerName: string;
 
-    bindListeners(instance: any): void;
-    bindListener(worker: cluster.Worker, instance: any): void;
-    bindMultipleListeners(instances: any[]): void;
+    bindListeners(instance: winston.Logger): void;
+    bindListener(worker: cluster.Worker, instance: winston.Logger): void;
+    bindMultipleListeners(instances: winston.Logger[]): void;
+    setMasterLogger(instance: winston.Logger): void;
     log(info: any, callback: Function): void;
 
     new(opts: transportStream.TransportStreamOptions, loggerName?: string): Cluster;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import * as cluster from 'cluster';
 
 declare namespace winstonCluster {
   interface Cluster extends transportStream {
-    masterLogger: winston.Logger;
+    BaseLogger: winston.Logger;
 
     name: string;
     silent: boolean;
@@ -13,7 +13,7 @@ declare namespace winstonCluster {
     bindListeners(instance: winston.Logger): void;
     bindListener(worker: cluster.Worker, instance: winston.Logger): void;
     bindMultipleListeners(instances: winston.Logger[]): void;
-    setMasterLogger(instance: winston.Logger): void;
+    setBaseLogger(instance: winston.Logger): void;
     log(info: any, callback: Function): void;
 
     new(opts: transportStream.TransportStreamOptions, loggerName?: string): Cluster;

--- a/lib/winston-cluster.js
+++ b/lib/winston-cluster.js
@@ -22,6 +22,9 @@ const winston = require('winston')
 const code = /\u001b\[(\d+(;\d+)*)?m/g;
 
 module.exports = class Cluster extends Transport {
+
+    static masterLogger = undefined;
+
     constructor(opts, loggerName = null) {
         super(opts)
         this.name = "cluster"
@@ -85,6 +88,10 @@ module.exports = class Cluster extends Transport {
         }
     }
 
+    static setMasterLogger(instance) {
+        Cluster.masterLogger = instance;
+    }
+
     //
     // #### @info {Object} 
     // #### @callback {function} Continuation to respond to when complete.
@@ -106,7 +113,12 @@ module.exports = class Cluster extends Transport {
             msg: message,
             meta: meta || {}
         };
-        process.send(message);
+        if (cluster.isWorker) {
+            process.send(message);
+        } else if (cluster.isMaster && Cluster.masterLogger) {
+            meta.loggerName = this.loggerName;
+            Cluster.masterLogger.log(level, message.msg, meta);
+        }
     
         callback();
     }

--- a/lib/winston-cluster.js
+++ b/lib/winston-cluster.js
@@ -23,7 +23,7 @@ const code = /\u001b\[(\d+(;\d+)*)?m/g;
 
 module.exports = class Cluster extends Transport {
 
-    static masterLogger = undefined;
+    static BaseLogger = undefined;
 
     constructor(opts, loggerName = null) {
         super(opts)
@@ -88,8 +88,8 @@ module.exports = class Cluster extends Transport {
         }
     }
 
-    static setMasterLogger(instance) {
-        Cluster.masterLogger = instance;
+    static setBaseLogger(instance) {
+        Cluster.BaseLogger = instance;
     }
 
     //
@@ -115,9 +115,9 @@ module.exports = class Cluster extends Transport {
         };
         if (cluster.isWorker) {
             process.send(message);
-        } else if (cluster.isMaster && Cluster.masterLogger) {
+        } else if (cluster.isMaster && Cluster.BaseLogger) {
             meta.loggerName = this.loggerName;
-            Cluster.masterLogger.log(level, message.msg, meta);
+            Cluster.BaseLogger.log(level, message.msg, meta);
         }
     
         callback();


### PR DESCRIPTION
Add static masterLogger, allows for multiple logger instances on master thread with only one instance logging to console or file.

This fixes an issue with winston-daily-rotate-file, which does not support multiple logger instances, and only logs from one instance will be written to file after the first file split.